### PR TITLE
Fix per multipli DNS custom

### DIFF
--- a/root/etc/e-smith/templates/etc/dnsmasq.conf/30dhcp
+++ b/root/etc/e-smith/templates/etc/dnsmasq.conf/30dhcp
@@ -48,9 +48,11 @@
 
             my $dns_server = $_->prop('DhcpDNS') || '';
             if ($dns_server ne '') {
+               $OUT .= "dhcp-option=$interface,option:dns-server";
                foreach (split(',',$dns_server)) {
-                   $OUT .= "dhcp-option=$interface,option:dns-server,$_\n";
+                  $OUT .= ",$_";
                }
+               $OUT .= "\n";
             }
 
             my $ntp_server = $_->prop('DhcpNTP') || '';


### PR DESCRIPTION
DNSmasq vuole solo una riga con option:dns-server, nel caso ce ne sono di più l'ultima riga sovrascrive le precedenti assegnazioni.

Questo succede anche sull'Enterprise, infatti è lì che mi sono accorto del problema in quanto mi ritornava un solo DNS e fatalità solo l'ultimo ;-)
