### PR TITLE
Remove deprecated InterfacesDB reference

### DIFF
--- a/root/etc/e-smith/templates/etc/dnsmasq.conf/00template_vars
+++ b/root/etc/e-smith/templates/etc/dnsmasq.conf/00template_vars
@@ -2,13 +2,7 @@
     #
     # 00template_vars
     #
-    use esmith::InterfacesDB;
-    $ndb = esmith::InterfacesDB->open_ro();
-
-    if( ! $ndb) {
-	my $msg = "Could not open InterfacesDB!";
-	warn $msg;
-	return "# " . $msg;
-    }
+    use esmith::NetworksDB;
+    $ndb = esmith::NetworksDB->open_ro();
     ''; # expand to an empty string
 }


### PR DESCRIPTION
The InterfacesDB class is an alias for NetworksDB and will be removed

NethServer/dev#5196