### PR TITLE
Skip dnsmasq access and status prop

### DIFF
--- a/root/etc/e-smith/db/configuration/defaults/dnsmasq/access
+++ b/root/etc/e-smith/db/configuration/defaults/dnsmasq/access
@@ -1,1 +1,1 @@
-private
+green

--- a/root/etc/e-smith/events/actions/nethserver-dnsmasq-migrate
+++ b/root/etc/e-smith/events/actions/nethserver-dnsmasq-migrate
@@ -46,12 +46,6 @@ $dstConfigDb->set_prop('dnsmasq', 'DhcpStatus', $status, type => 'service');
 $dstConfigDb->set_prop('dnsmasq', 'DhcpRangeStart', $start, type => 'service');
 $dstConfigDb->set_prop('dnsmasq', 'DhcpRangeEnd', $end, type => 'service');
 
-my $dnscache = $srcConfigDb->get('dnscache');
-my $status = $dnscache->prop('status') || 'disabled';
-my $access = $dnscache->prop('access') || 'private';
-$dstConfigDb->set_prop('dnsmasq', 'status', $status, type => 'service');
-$dstConfigDb->set_prop('dnsmasq', 'access', $access, type => 'service');
-
 #
 # Apply configuration
 # 


### PR DESCRIPTION
In ns7 dnsmasq service must always be running and accessible.

NethServer/dev#5196