### PR TITLE
tftp: enable also for blue interfaces

### DIFF
--- a/root/etc/e-smith/templates/etc/dnsmasq.conf/30dhcp
+++ b/root/etc/e-smith/templates/etc/dnsmasq.conf/30dhcp
@@ -75,8 +75,8 @@
                    $OUT .= "dhcp-option=tag:$interface,option:tftp-server,\"$_\"\n";
                }
             } else {
-               if ( $tftpstatus eq 'enabled' && $role eq 'green' ) {
-                   $OUT .= "dhcp-option=tag:$interface,option:tftp-server,\"$ipaddr\"\n";
+               if ($tftpstatus eq 'enabled') {
+                   $OUT .= "dhcp-option=tag:$interface,option:tftp-server,$ipaddr\n";
                }
             }
 


### PR DESCRIPTION
Preserve backward compatible behavior:
if tftp-status is enabled, the option 66 must be
available on all interfaces.

NethServer/dev#5616