### PR TITLE
Specify dns server redirection per domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,7 @@ Properties:
 * ``except-interface``: comma-separated list of interfaces. Do not listen to listed interfaces, useful to avoid conflicts with libvirt
 * ``tftp-status``: can be ``enabled`` or ``disabled``. If enabled, enable the TFTP server for BOOTP (port 67)
 * ``access``: default is ``private``, do NOT set to ``public``
+* ``DomainRedirection``: specify a dns server for a particular domain (comma separated). The ``domain.org:192.168.1.1`` will send all queries ``*.domain.org`` for internal machines to ``192.168.1.1``. The special server address ``#`` means, "use the standard servers", so ``sub.domain.org:#`` will send all queries for ``*sub.domain.org`` to the default DNS server of the domain name.
 
 Database example: ::
 
@@ -102,14 +103,14 @@ Database example: ::
     AllowHosts=
     CacheSize=4000
     DenyHosts=
+    DomainRedirection=domain.org:192.168.1.1,sub.domain.org:#
     TCPPort=53
     UDPPorts=53,67
     access=private
     dhcp-boot=pxelinux.0,myserver.mydomain.com,192.168.1.1
     except-interface=virbr0,tunspot
     status=enabled
-    tftp-status=enabled
-
+    tftp-status
 
 DHCP
 ====
@@ -267,18 +268,3 @@ Copy inside the directory :file:`vmlinuz` and :file:`initrd.img` files. These fi
 Change files owner to nobody: ::
 
  chown -R nobody /var/lib/tftpboot/*
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/root/etc/e-smith/templates/etc/dnsmasq.conf/55DomainRedirection
+++ b/root/etc/e-smith/templates/etc/dnsmasq.conf/55DomainRedirection
@@ -1,12 +1,6 @@
 #
 # 55DomainRedirection
 #
-# This is intended for private nameservers: if you have a nameserver on your network which deals with names of the form
-# xxx.internal.thekelleys.org.uk at 192.168.1.1 then giving  the server=/internal.thekelleys.org.uk/192.168.1.1  will
-# send all queries for internal machines to that nameserver, everything else will go to the servers in /etc/resolv.conf
-# The  special  server  address '#'means, "use the standard servers", so server=/google.com/1.2.3.4
-# server=/www.google.com/# will send queries for *.google.com to 1.2.3.4, except *www.google.com which will be for‐
-# warded as usual.
 
 {
     foreach ( split(',',$dnsmasq{'DomainRedirection'} || '')) {

--- a/root/etc/e-smith/templates/etc/dnsmasq.conf/55DomainRedirection
+++ b/root/etc/e-smith/templates/etc/dnsmasq.conf/55DomainRedirection
@@ -1,0 +1,20 @@
+#
+# 55DomainRedirection
+#
+# This is intended for private nameservers: if you have a nameserver on your network which deals with names of the form
+# xxx.internal.thekelleys.org.uk at 192.168.1.1 then giving  the server=/internal.thekelleys.org.uk/192.168.1.1  will
+# send all queries for internal machines to that nameserver, everything else will go to the servers in /etc/resolv.conf
+# The  special  server  address '#'means, "use the standard servers", so server=/google.com/1.2.3.4
+# server=/www.google.com/# will send queries for *.google.com to 1.2.3.4, except *www.google.com which will be for‐
+# warded as usual.
+
+{
+    foreach ( split(',',$dnsmasq{'DomainRedirection'} || '')) {
+        my ($domain, $direction) = split(':', $_);
+
+        if(!$domain) {
+            next;
+        }
+        $OUT .= "server=/$domain/$direction\n";
+    }
+}


### PR DESCRIPTION
The server=/internal.thekelleys.org.uk/192.168.1.1  will send all queries for internal machines to that nameserver. The  special  server  address '#' means, "use the standard servers", so server=/google.com/1.2.3.4 server=/www.google.com/# will send queries for *.google.com 
to 1.2.3.4, except *www.google.com which will be forwarded as usual.


https://github.com/NethServer/dev/issues/6082